### PR TITLE
Update README for new settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ python main.py
 - "Единица измерения" — choose units (m² or linear meters).
 - "Система налогов" — input your tax percentage.
 - "Стоимость замеров" — configure fixed price and per‑kilometer price for measurements.
-- "ЗП Мастера" / "ЗП Монтажника" — set wages for each role.
+- "МОП" — set overhead percentage.
+- "Маржа" — set profit margin.
+- "ЗП Мастера" / "ЗП Монтажника" — set wages for each role. Installer delivery now has fixed and per‑kilometer components, editable from this menu.
 - "Далее" opens extra menus to provide dimensions, material prices and other values.
 - "Рассчитать" — receive a detailed breakdown of material cost and salaries.
 


### PR DESCRIPTION
## Summary
- document overhead and margin options
- note that installer delivery has fixed and per-kilometer parts

## Testing
- `python -m py_compile main.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_68430185583c8332844c2e446a2e4c30