### PR TITLE
Add new states for stone-specific percentages

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,6 +58,9 @@ class Settings(StatesGroup):
     menu3_km = State()  # ввод «Сколько КМ?»
     menu3_mop = State()  # ввод «проценты МОПу»
     menu3_margin = State()  # ввод «маржа»
+    tax_stone = State()
+    mop_stone = State()
+    margin_stone = State()
 
 # ─── 2) Инициализация базы ────────────────────────────────────
 async def init_db():


### PR DESCRIPTION
## Summary
- extend Settings FSM with states for choosing stone type for tax, mop and margin

## Testing
- `python -m py_compile db.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6845dd7760b883328ae03d8841ac4101