### PR TITLE
Add per-stone tax, mop and margin

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,6 +58,9 @@ class Settings(StatesGroup):
     menu3_km = State()  # ввод «Сколько КМ?»
     menu3_mop = State()  # ввод «проценты МОПу»
     menu3_margin = State()  # ввод «маржа»
+    tax_stone    = State()  # выбор камня для налогов
+    mop_stone    = State()  # выбор камня для МОП
+    margin_stone = State()  # выбор камня для маржи
 
 # ─── 2) Инициализация базы ────────────────────────────────────
 async def init_db():
@@ -157,6 +160,15 @@ async def init_db():
             if col not in cols:
                 await db.execute(f"ALTER TABLE user_settings ADD COLUMN {col} TEXT DEFAULT 'не указано'")
 
+        # дополнительные колонки для налогов/МОП/маржи по камням
+        for col in (
+            "tax_acryl", "tax_quartz",
+            "mop_acryl", "mop_quartz",
+            "margin_acryl", "margin_quartz",
+        ):
+            if col not in cols:
+                await db.execute(f"ALTER TABLE user_settings ADD COLUMN {col} TEXT DEFAULT 'не указано'")
+
         await db.commit()
 
 # ─── конец init_db() ──────────────────────────────────────────
@@ -221,10 +233,9 @@ async def set_installer_unit(chat_id: int, value: str):
 
 
 async def get_tax(chat_id: int) -> str:
-    async with connection() as db:
-        cur = await db.execute("SELECT tax_percent FROM user_settings WHERE chat_id = ?", (chat_id,))
-        row = await cur.fetchone()
-        return row[0] if row else "не указано"
+    quartz = await get_tax_value(chat_id, "quartz")
+    acryl  = await get_tax_value(chat_id, "acryl")
+    return f"кварц {quartz}% | акрил {acryl}%"
 
 
 async def set_tax(chat_id: int, value: str):
@@ -477,10 +488,9 @@ async def set_menu3_km(chat_id: int, value: str):
         await db.commit()
 
 async def get_menu3_mop(chat_id: int) -> str:
-    async with connection() as db:
-        cur = await db.execute("SELECT menu3_mop FROM user_settings WHERE chat_id = ?", (chat_id,))
-        row = await cur.fetchone()
-        return row[0] if row else "не указано"
+    quartz = await get_mop_value(chat_id, "quartz")
+    acryl  = await get_mop_value(chat_id, "acryl")
+    return f"кварц {quartz}% | акрил {acryl}%"
 
 async def set_menu3_mop(chat_id: int, value: str):
     async with connection() as db:
@@ -492,10 +502,9 @@ async def set_menu3_mop(chat_id: int, value: str):
         await db.commit()
 
 async def get_menu3_margin(chat_id: int) -> str:
-    async with connection() as db:
-        cur = await db.execute("SELECT menu3_margin FROM user_settings WHERE chat_id = ?", (chat_id,))
-        row = await cur.fetchone()
-        return row[0] if row else "не указано"
+    quartz = await get_margin_value(chat_id, "quartz")
+    acryl  = await get_margin_value(chat_id, "acryl")
+    return f"кварц {quartz}% | акрил {acryl}%"
 
 async def set_menu3_margin(chat_id: int, value: str):
     async with connection() as db:
@@ -504,6 +513,67 @@ async def set_menu3_margin(chat_id: int, value: str):
             VALUES (?, ?)
             ON CONFLICT(chat_id) DO UPDATE SET menu3_margin = excluded.menu3_margin
         """, (chat_id, value))
+        await db.commit()
+
+# ─── новые функции для налогов/МОП/маржи по типу камня ───────────
+async def get_tax_value(chat_id: int, stone: str) -> str:
+    column = f"tax_{stone}"
+    async with connection() as db:
+        cur = await db.execute(f"SELECT {column} FROM user_settings WHERE chat_id = ?", (chat_id,))
+        row = await cur.fetchone()
+        return row[0] if row else "не указано"
+
+async def set_tax_value(chat_id: int, stone: str, value: str):
+    column = f"tax_{stone}"
+    async with connection() as db:
+        await db.execute(
+            f"""
+            INSERT INTO user_settings(chat_id, {column})
+            VALUES (?, ?)
+            ON CONFLICT(chat_id) DO UPDATE SET {column} = excluded.{column}
+            """,
+            (chat_id, value),
+        )
+        await db.commit()
+
+async def get_mop_value(chat_id: int, stone: str) -> str:
+    column = f"mop_{stone}"
+    async with connection() as db:
+        cur = await db.execute(f"SELECT {column} FROM user_settings WHERE chat_id = ?", (chat_id,))
+        row = await cur.fetchone()
+        return row[0] if row else "не указано"
+
+async def set_mop_value(chat_id: int, stone: str, value: str):
+    column = f"mop_{stone}"
+    async with connection() as db:
+        await db.execute(
+            f"""
+            INSERT INTO user_settings(chat_id, {column})
+            VALUES (?, ?)
+            ON CONFLICT(chat_id) DO UPDATE SET {column} = excluded.{column}
+            """,
+            (chat_id, value),
+        )
+        await db.commit()
+
+async def get_margin_value(chat_id: int, stone: str) -> str:
+    column = f"margin_{stone}"
+    async with connection() as db:
+        cur = await db.execute(f"SELECT {column} FROM user_settings WHERE chat_id = ?", (chat_id,))
+        row = await cur.fetchone()
+        return row[0] if row else "не указано"
+
+async def set_margin_value(chat_id: int, stone: str, value: str):
+    column = f"margin_{stone}"
+    async with connection() as db:
+        await db.execute(
+            f"""
+            INSERT INTO user_settings(chat_id, {column})
+            VALUES (?, ?)
+            ON CONFLICT(chat_id) DO UPDATE SET {column} = excluded.{column}
+            """,
+            (chat_id, value),
+        )
         await db.commit()
 
 # ─── далее продолжается остальной код ────────────────────────
@@ -534,13 +604,13 @@ def main_menu(tax_value: str, fix_value: str, km_value: str, mop_value: str, mar
     return InlineKeyboardMarkup(inline_keyboard=[
         [InlineKeyboardButton(text="ЗП Мастера", callback_data="salary_master")],
         [InlineKeyboardButton(text="ЗП Монтажника", callback_data="salary_installer")],
-        [InlineKeyboardButton(text=f"Система налогов | {tax_value}%", callback_data="set_tax_system")],
+        [InlineKeyboardButton(text=f"Система налогов | {tax_value}", callback_data="set_tax_system")],
         [InlineKeyboardButton(
             text=f"Стоимость замеров | Фикс {fix_value} | КМ {km_value}",
             callback_data="set_measurement_cost"
         )],
-        [InlineKeyboardButton(text=f"МОП | {mop_value}%", callback_data="set_mop")],
-        [InlineKeyboardButton(text=f"Маржа | {margin_value}%", callback_data="set_margin")],
+        [InlineKeyboardButton(text=f"МОП | {mop_value}", callback_data="set_mop")],
+        [InlineKeyboardButton(text=f"Маржа | {margin_value}", callback_data="set_margin")],
         [InlineKeyboardButton(text="Просчёт изделия", callback_data="to_menu2")],
     ])
 
@@ -707,6 +777,7 @@ async def menu3_km_input(message: Message, state: FSMContext):
     menu3_id   = data.get("menu3_message_id")
     menu_id    = data.get("menu_message_id")
     prompt_id  = data.get("prompt_id")
+    stone      = data.get("stone")
     text       = message.text.strip()
     if not text.isdigit():
         return await message.reply("Неверный формат. Введите целое число, например: 10")
@@ -753,10 +824,14 @@ async def menu3_mop_input(message: Message, state: FSMContext):
     menu3_id   = data.get("menu3_message_id")
     menu_id    = data.get("menu_message_id")
     prompt_id  = data.get("prompt_id")
+    stone      = data.get("stone")
     text       = message.text.strip()
     if not text.isdigit() or not (0 <= int(text) <= 100):
         return await message.reply("Неверный формат. Введите целое число от 0 до 100.")
-    await set_menu3_mop(message.chat.id, text)
+    if stone:
+        await set_mop_value(message.chat.id, stone, text)
+    else:
+        await set_menu3_mop(message.chat.id, text)
     await message.delete()
     if prompt_id:
         await message.bot.delete_message(chat_id=message.chat.id, message_id=prompt_id)
@@ -804,7 +879,10 @@ async def menu3_margin_input(message: Message, state: FSMContext):
     text       = message.text.strip()
     if not text.isdigit() or not (0 <= int(text) <= 100):
         return await message.reply("Неверный формат. Введите целое число от 0 до 100.")
-    await set_menu3_margin(message.chat.id, text)
+    if stone:
+        await set_margin_value(message.chat.id, stone, text)
+    else:
+        await set_menu3_margin(message.chat.id, text)
     await message.delete()
     if prompt_id:
         await message.bot.delete_message(chat_id=message.chat.id, message_id=prompt_id)
@@ -903,13 +981,26 @@ async def unit_choice(call: CallbackQuery, state: FSMContext):
 
 
 async def set_tax_menu(call: CallbackQuery, state: FSMContext):
-    # Переходим в состояние ввода налога
-    await state.set_state(Settings.tax)
-    # Сохраняем ID этого сообщения
+    await state.set_state(Settings.tax_stone)
     await state.update_data(menu_message_id=call.message.message_id)
-    # Отправляем отдельное сообщение с запросом
-    msg = await call.message.answer("Введи, какой процент налогов ты платишь:")
+    kb = InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="Акрил", callback_data="tax_stone_acryl")],
+        [InlineKeyboardButton(text="Кварц", callback_data="tax_stone_quartz")],
+    ])
+    msg = await call.message.answer("Выберите тип камня:", reply_markup=kb)
     await state.update_data(prompt_id=msg.message_id)
+    await call.answer()
+
+async def tax_stone_choice(call: CallbackQuery, state: FSMContext):
+    stone = "acryl" if call.data.endswith("acryl") else "quartz"
+    data = await state.get_data()
+    prompt_id = data.get("prompt_id")
+    await state.set_state(Settings.tax)
+    await state.update_data(stone=stone)
+    await safe_edit_message_text(
+        call.message.edit_text,
+        "Введите процент (целое число от 0 до 100):",
+    )
     await call.answer()
 
 
@@ -917,13 +1008,17 @@ async def tax_input(message: Message, state: FSMContext):
     data = await state.get_data()
     menu_id = data.get("menu_message_id")
     prompt_id = data.get("prompt_id")
+    stone = data.get("stone")
 
     text = message.text.strip().rstrip('%')
     if not text.isdigit():
         return await message.reply("Неверный формат. Введите число (например, 15).")
 
     # 1) Сохраняем процент в БД
-    await set_tax(message.chat.id, text)
+    if stone:
+        await set_tax_value(message.chat.id, stone, text)
+    else:
+        await set_tax(message.chat.id, text)
 
     # 2) Удаляем сообщение пользователя и подсказку
     await message.bot.delete_message(chat_id=message.chat.id, message_id=message.message_id)
@@ -1023,17 +1118,45 @@ async def price_inst_deliv_km_input(message: Message, state: FSMContext):
     )
 
 async def set_mop_main(call: CallbackQuery, state: FSMContext):
-    await state.set_state(Settings.menu3_mop)
+    await state.set_state(Settings.mop_stone)
     await state.update_data(menu_message_id=call.message.message_id)
-    msg = await call.message.answer("Введите проценты МОПу (целое число от 0 до 100):")
+    kb = InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="Акрил", callback_data="mop_stone_acryl")],
+        [InlineKeyboardButton(text="Кварц", callback_data="mop_stone_quartz")],
+    ])
+    msg = await call.message.answer("Выберите тип камня:", reply_markup=kb)
     await state.update_data(prompt_id=msg.message_id)
     await call.answer()
 
+async def mop_stone_choice(call: CallbackQuery, state: FSMContext):
+    stone = "acryl" if call.data.endswith("acryl") else "quartz"
+    await state.set_state(Settings.menu3_mop)
+    await state.update_data(stone=stone)
+    await safe_edit_message_text(
+        call.message.edit_text,
+        "Введите проценты МОПу (целое число от 0 до 100):",
+    )
+    await call.answer()
+
 async def set_margin_main(call: CallbackQuery, state: FSMContext):
-    await state.set_state(Settings.menu3_margin)
+    await state.set_state(Settings.margin_stone)
     await state.update_data(menu_message_id=call.message.message_id)
-    msg = await call.message.answer("Введите маржу в % (целое число от 0 до 100):")
+    kb = InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="Акрил", callback_data="margin_stone_acryl")],
+        [InlineKeyboardButton(text="Кварц", callback_data="margin_stone_quartz")],
+    ])
+    msg = await call.message.answer("Выберите тип камня:", reply_markup=kb)
     await state.update_data(prompt_id=msg.message_id)
+    await call.answer()
+
+async def margin_stone_choice(call: CallbackQuery, state: FSMContext):
+    stone = "acryl" if call.data.endswith("acryl") else "quartz"
+    await state.set_state(Settings.menu3_margin)
+    await state.update_data(stone=stone)
+    await safe_edit_message_text(
+        call.message.edit_text,
+        "Введите маржу в % (целое число от 0 до 100):",
+    )
     await call.answer()
 
 async def salary_role_menu(call: CallbackQuery, state: FSMContext):
@@ -1925,10 +2048,10 @@ async def calculate_handler(call: CallbackQuery, state: FSMContext):
     ]
 
     # ─── 6) Итоговая стоимость для клиента ─────────────────────────
-    # читаем проценты: маржа, МОП (menu3_mop), налог из меню 1
-    raw_margin = await get_menu3_margin(chat_id)  # строка, напр. "15" или "не указано"
-    raw_mop = await get_menu3_mop(chat_id)  # строка, напр. "5" или "не указано"
-    raw_tax = await get_tax(chat_id)  # строка, напр. "13" или "не указано"
+    # читаем проценты с учётом выбранного камня
+    raw_margin = await get_margin_value(chat_id, stone_key)
+    raw_mop    = await get_mop_value(chat_id, stone_key)
+    raw_tax    = await get_tax_value(chat_id, stone_key)
 
     # преобразуем к float, если не указано — 0
     margin = float(raw_margin) if raw_margin.isdigit() else 0.0
@@ -1998,6 +2121,7 @@ async def main():
     dp.callback_query.register(unit_choice,   lambda c: c.data in ("unit_m2", "unit_mp"))
 
     dp.callback_query.register(set_tax_menu,   lambda c: c.data == "set_tax_system")
+    dp.callback_query.register(tax_stone_choice, lambda c: c.data in {"tax_stone_acryl", "tax_stone_quartz"})
     dp.message.register     (tax_input, Settings.tax)
 
     dp.callback_query.register(set_measurement_menu, lambda c: c.data == "set_measurement_cost")
@@ -2007,7 +2131,9 @@ async def main():
     dp.message.register(meas_fix_input, Settings.meas_fix)
     dp.message.register(price_inst_deliv_km_input, Settings.meas_km)
     dp.callback_query.register(set_mop_main, lambda c: c.data == "set_mop")
+    dp.callback_query.register(mop_stone_choice, lambda c: c.data in {"mop_stone_acryl", "mop_stone_quartz"})
     dp.callback_query.register(set_margin_main, lambda c: c.data == "set_margin")
+    dp.callback_query.register(margin_stone_choice, lambda c: c.data in {"margin_stone_acryl", "margin_stone_quartz"})
     # dp.callback_query.register(set_master_menu, lambda c: c.data == "set_master_salary")
     # dp.callback_query.register(master_type_choice, lambda c: c.data in ("master_acryl", "master_quartz"))
     # dp.callback_query.register(master_type_back, lambda c: c.data == "master_back")


### PR DESCRIPTION
## Summary
- add FSM states for stone-specific settings
- store tax/mop/margin values separately for acrylic and quartz
- show stone choice when editing these values from the main menu
- apply selected stone when saving values
- display tax/mop/margin for both stones in the main menu

## Testing
- `python -m py_compile main.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_6845dd7b3b4883329e54b6775c870d13