### PR TITLE
Fix duplicate value assignments

### DIFF
--- a/main.py
+++ b/main.py
@@ -1317,8 +1317,6 @@ async def back_to_menu2(call: CallbackQuery, state: FSMContext):
     ed   = await get_menu2_value(chat_id, "edges", "м/п")
     km_val    = await get_menu3_km(chat_id)
     takel_val = await get_menu2_takelage(chat_id)
-    km_val = await get_menu3_km(chat_id)
-    takel_val = await get_menu2_takelage(chat_id)
     await safe_edit_message_text(call.message.edit_text, 
         "Основное меню 2:",
         reply_markup=menu2_kb(


### PR DESCRIPTION
## Summary
- remove duplicate assignments to `km_val` and `takel_val`

## Testing
- `python -m py_compile main.py db.py`
- `python - <<'PY'
from main import menu2_kb
kb = menu2_kb('stone', '1000', 'cntp', 'wal', '2', '3', 'gl', 'ed', '10', 'yes', 'm2')
for row in kb.inline_keyboard:
    print([button.text for button in row])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6848031c63448332a134a8925a802493