### PR TITLE
Fix duplicate column additions

### DIFF
--- a/main.py
+++ b/main.py
@@ -200,15 +200,6 @@ async def init_db():
                 )
 
 
-        # дополнительные колонки для налогов/МОП/маржи по камням
-        for col in (
-            "tax_acryl", "tax_quartz",
-            "mop_acryl", "mop_quartz",
-            "margin_acryl", "margin_quartz",
-        ):
-            if col not in cols:
-                await db.execute(f"ALTER TABLE user_settings ADD COLUMN {col} TEXT DEFAULT 'не указано'")
-
 
         await db.commit()
 


### PR DESCRIPTION
## Summary
- clean up `init_db` to remove duplicate column additions for tax, mop, and margin

## Testing
- `python3 -m py_compile main.py db.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485ff6c3fc83328d2bebf4103f92f9