### PR TITLE
Reduce long-polling delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The bot stores user settings in `settings.db`. The database is created and initi
 ```bash
 python main.py
 ```
+The dispatcher uses long polling. The code sets `polling_timeout=1` so the bot
+responds quickly even after periods of inactivity. Adjust this value if you
+need a different balance between latency and network traffic.
 
 ## Main commands
 - `/start` — reset the state and open the main menu.

--- a/main.py
+++ b/main.py
@@ -2748,7 +2748,7 @@ async def main():
 
     # Запускаем long-polling
     try:
-        await dp.start_polling(bot)
+        await dp.start_polling(bot, polling_timeout=1)
     finally:
         await close_db()
         await bot.session.close()


### PR DESCRIPTION
## Summary
- drop long wait time when bot wakes up by setting `polling_timeout=1`
- document the new timeout setting in README

## Testing
- `pip install aiogram==3.0.0b4`


------
https://chatgpt.com/codex/tasks/task_e_684c0e4c501883328a47a8d2d19e7681